### PR TITLE
vimrc: enable fzf's ag to ignore tags file

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -902,7 +902,7 @@ if exists('g:plugs["fzf.vim"]')
 	" Search only the local buffer for the specific tag
 	nmap <Leader>ft :BTags<CR>
 	" Use AG for some fuzzy find
-	nmap <Leader>fa :Ag<Space>
+	nmap <Leader>fa :Ag --ignore tags<Space>
 	" Search only for git tracked files
 	nnoremap <C-p> :GFiles<CR>
 	" Search for non-git tracked files


### PR DESCRIPTION
No need to show the tag file as part of the AG results when searching for something with fzf.

Signed-off-by: Dan Kalowsky <dank@deadmime.org>