### PR TITLE
vimrc: load tokyonights only on neovim

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -54,9 +54,7 @@ let mapleader=","
 set encoding=utf-8
 
 " vim UI settings {{{
-set nu rnu
-"set norelativenumber
-"set relativenumber
+set number
 set wildmenu         " visual autocomplete for command menu
 set wildmode=longest,list:full " match to the longest string possible
 set wildignore=*.o,*.obj,*~

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -455,12 +455,14 @@ if exists('g:plugs["vim-colors-solarized"]')
   colorscheme solarized
 endif
 
+if has('nvim')
 if exists('g:plugs["tokyonight.nvim"]')
   let g:tokyonight_style = "night"
   let g:tokyonight_italic_functions = 1
   let g:tokyonight_sidebars = [ "qf", "vista_kind", "terminal", "packer" ]
 
   colorscheme tokyonight
+endif
 endif
 
 " }}}

--- a/vim/.vimrc.bundles.local
+++ b/vim/.vimrc.bundles.local
@@ -1,6 +1,6 @@
 "
 " plug-ins to add
-"Plug 'altercation/vim-colors-solarized'
+Plug 'altercation/vim-colors-solarized'
 Plug 'benjifisher/matchit.zip'
 Plug 'cespare/vim-toml', { 'branch': 'main' }
 Plug 'danilamihailov/beacon.nvim'


### PR DESCRIPTION
The colorscheme tokyo nights does not support vim as far as I can tell.
Only load this on neovim.  Do this by overriding the first load of
solarized.

Signed-off-by: Dan Kalowsky <dank@deadmime.org>